### PR TITLE
Fix the app title appearing as "Searching..." on first load

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:preferences/preference_service.dart';
 import 'package:provider/provider.dart';
+import 'package:tuple/tuple.dart';
 
 import './settings.dart';
 import '../cards/graph.dart';
@@ -28,54 +29,55 @@ class AppState extends State<HomePage> {
       return SettingsPage();
     }
 
-    return Consumer<LocationModel>(
-      builder: ( context, location, child ) {
-        return Consumer<WeatherModel>(
-          builder: ( context, weather, child ) {
-            if ( location.location.countryCode != null && location.location.countryCode != 'AU' ) {
-              return Scaffold(
-                appBar: AppBar(
-                  title: Text( 'Outside Australia' ),
-                ),
-                drawer: buildDrawer( context, HomePage.route ),
-                body: Padding(
-                  padding: const EdgeInsets.symmetric( horizontal: 16.0, vertical: 12.0 ),
-                  child: Text( "Thanks for trying out Tidy Weather! We're currently only available in Australia, but will be expanding to other locations soon!" ),
-                ),
-              );
+    return Selector2<LocationModel, WeatherModel, Tuple3<String, String, bool>>(
+      selector: ( context, location, weather ) => Tuple3(
+        location.location.countryCode,
+        location.location.name,
+        weather.today.observations.temperature.temperature == null
+      ),
+      builder: ( context, data, child ) {
+        if ( data.item1 != null && data.item1 != 'AU' ) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text( 'Outside Australia' ),
+            ),
+            drawer: buildDrawer( context, HomePage.route ),
+            body: Padding(
+              padding: const EdgeInsets.symmetric( horizontal: 16.0, vertical: 12.0 ),
+              child: Text( "Thanks for trying out Tidy Weather! We're currently only available in Australia, but will be expanding to other locations soon!" ),
+            ),
+          );
 
-            }
+        }
 
-            if ( weather.today.observations.temperature.temperature == null ) {
-              return Scaffold(
-                appBar: AppBar(
-                  title: Text( location.location.name ),
-                ),
-                drawer: buildDrawer( context, HomePage.route ),
-                body: Center(
-                  child: CircularProgressIndicator(),
-                ),
-              );
-            }
+        if ( data.item3 ) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text( data.item2 ),
+            ),
+            drawer: buildDrawer( context, HomePage.route ),
+            body: Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
 
-            return Scaffold(
-              appBar: AppBar(
-                title: Text( location.location.name ),
-              ),
-              drawer: buildDrawer( context, HomePage.route ),
-              body: RefreshIndicator(
-                onRefresh: LocationModel.load,
-                child: ListView(
-                  children: <Widget>[
-                    TodayCard(),
-                    WeekCard(),
-                    GraphCard(),
-                    TodayDetailsCard(),
-                  ],
-                ),
-              ),
-            );
-          },
+        return Scaffold(
+          appBar: AppBar(
+            title: Text( data.item2 ),
+          ),
+          drawer: buildDrawer( context, HomePage.route ),
+          body: RefreshIndicator(
+            onRefresh: LocationModel.load,
+            child: ListView(
+              children: <Widget>[
+                TodayCard(),
+                WeekCard(),
+                GraphCard(),
+                TodayDetailsCard(),
+              ],
+            ),
+          ),
         );
       },
     );


### PR DESCRIPTION
Fixes #29.

It seems that nested `Consumer`s can cause confusion, particularly when things can change based on a combination of the data from each `Consumer`.

Replacing this with a `Selector2` has multiple benefits:

- Only a single `builder` function, so it doesn't need to watch both.
- The data being watched is simplified, reducing the chance of confusion.
- Only watching the data we need ensures fewer interface rebuilds.