### PR TITLE
Fix AppBar scroll performance.

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,6 +1,5 @@
 
 import 'package:flutter/material.dart';
-import 'package:gradient_app_bar/gradient_app_bar.dart';
 import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
 
@@ -12,7 +11,7 @@ import '../cards/week.dart';
 import '../data/location_model.dart';
 import '../data/weather_model.dart';
 import '../widgets/drawer.dart';
-import '../widgets/weatherGradient.dart';
+import '../widgets/FadingAppBarScaffold.dart';
 
 class HomePage extends StatefulWidget {
   static const String route = '/';
@@ -22,13 +21,13 @@ class HomePage extends StatefulWidget {
 }
 
 class AppState extends State<HomePage> {
-  double _scrollPixels;
+  ScrollController _scrollController;
 
   @override
   void initState() {
     super.initState();
+    _scrollController = ScrollController();
 
-    _scrollPixels = 0;
   }
 
   @override
@@ -66,27 +65,19 @@ class AppState extends State<HomePage> {
           );
         }
 
-        double opacity;
-        if ( _scrollPixels >= 200 ) {
-          opacity = 1;
-        } else {
-          opacity = _scrollPixels / 200;
-        }
+        ThemeData _modifiedTheme = Theme.of( context ).copyWith( appBarTheme: AppBarTheme( color: Colors.transparent ) );
 
-        Scaffold _scaffold = Scaffold(
-          appBar: GradientAppBar(
-            title: Text( data.item2 ),
-            gradient: weatherGradient( context, data.item3.forecast.weather.code, opacity ),
-            elevation: 0,
-          ),
-          drawer: buildDrawer( context, HomePage.route ),
-          extendBodyBehindAppBar: true,
-          body: RefreshIndicator(
-            onRefresh: LocationModel.load,
-            child: NotificationListener<ScrollNotification>(
+        return Theme(
+          data: _modifiedTheme,
+          child: FadingAppBarScaffold(
+            controller: _scrollController,
+            title: data.item2,
+            weatherCode: data.item3.forecast.weather.code,
+            body: RefreshIndicator(
+              onRefresh: LocationModel.load,
               child: ListView(
                 padding: EdgeInsets.zero,
-                primary: true,
+                controller: _scrollController,
                 children: <Widget>[
                   TodayCard(),
                   WeekCard(),
@@ -95,22 +86,10 @@ class AppState extends State<HomePage> {
                   RadarCard(),
                 ],
               ),
-              onNotification: ( ScrollNotification scrollInfo ) {
-                setState( () => _scrollPixels = scrollInfo.metrics.pixels );
-                return false;
-              },
             ),
           ),
-        );
-
-        ThemeData _modifiedTheme = Theme.of( context ).copyWith( appBarTheme: AppBarTheme( color: Colors.transparent ) );
-
-        return Theme(
-          data: _modifiedTheme,
-          child: _scaffold,
         );
       },
     );
   }
 }
-

--- a/lib/widgets/FadingAppBarScaffold.dart
+++ b/lib/widgets/FadingAppBarScaffold.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:gradient_app_bar/gradient_app_bar.dart';
+
+import '../pages/home.dart';
+import '../widgets/drawer.dart';
+import '../widgets/weatherGradient.dart';
+
+class FadingAppBarScaffold extends StatefulWidget {
+  const FadingAppBarScaffold( {
+    Key key,
+    this.body,
+    this.title,
+    this.weatherCode,
+    this.controller,
+  } ) : super( key: key );
+
+  final Widget body;
+  final String title;
+  final String weatherCode;
+  final ScrollController controller;
+
+  @override
+  State<StatefulWidget> createState() => FadingAppBarScaffoldState();
+}
+
+class FadingAppBarScaffoldState extends State<FadingAppBarScaffold> {
+  double _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _opacity = 0;
+    widget.controller.addListener( _updateOpacity );
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener( _updateOpacity );
+    super.dispose();
+  }
+
+  void _updateOpacity() {
+    double newOpacity;
+    if ( widget.controller.position.pixels >= 200 ) {
+      newOpacity = 1;
+    } else {
+      newOpacity = widget.controller.position.pixels / 200;
+    }
+
+    if ( _opacity != newOpacity ) {
+      setState( () => _opacity = newOpacity );
+    }
+  }
+
+  @override
+  Widget build( BuildContext context ) {
+    return Scaffold(
+      body: widget.body,
+      drawer: buildDrawer( context, HomePage.route ),
+      extendBodyBehindAppBar: true,
+      appBar: GradientAppBar(
+        title: Text( widget.title ),
+        gradient: weatherGradient( context, widget.weatherCode, _opacity ),
+        elevation: 0,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
#47 introduces performance issues when scrolling on the home page.

This was caused by the `AppBar` opacity being calculated within `HomePage`, which forced the entire page to be laid out every time it changed. Additionally, the `ScrollNotification` event is triggered after layout, which meant the opacity changed after everything had already been laid out, triggering a second re-layout.

This changed fixes the problem by keeping the page layout in `HomePage`, but pushing the `AppBar` layout down into a sub-widget. It also hooks into the main `ListView`'s `ScrollController` for getting scroll updates, which gives updates _before_ layout happens.

Finally, for a little extra nudge, the `setState()` call triggered by scroll events is only called if the scroll position actually changes.