### PR TITLE
Improve permission handling

### DIFF
--- a/android/app/src/main/kotlin/net/pento/tidyweather/WeatherWidget.kt
+++ b/android/app/src/main/kotlin/net/pento/tidyweather/WeatherWidget.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.util.Log
 import android.widget.RemoteViews
 import java.time.LocalDateTime
+import java.time.format.DateTimeParseException
 import kotlin.collections.HashMap
 
 /**
@@ -44,7 +45,13 @@ internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManage
 
     val now = LocalDateTime.now()
 
-    val night = now.isBefore( LocalDateTime.parse( sunrise) ) || now.isAfter( LocalDateTime.parse( sunset ) )
+    var night = false
+    try {
+        night = now.isBefore( LocalDateTime.parse( sunrise ) ) || now.isAfter( LocalDateTime.parse( sunset ) )
+    } catch ( e: DateTimeParseException ) {
+        // Encountered an invalid date, so default to daytime.
+        Log.d( "TidyWeather", "Encountered invalid date whilst updating widget. Sunrise: $sunrise. Sunset: $sunset" )
+    }
 
     // Construct the RemoteViews object
     val views = RemoteViews( context.packageName, R.layout.weather_widget )

--- a/lib/cards/today_details.dart
+++ b/lib/cards/today_details.dart
@@ -131,7 +131,7 @@ class _TodayDetailsCardState extends State<TodayDetailsCard> {
                       icon: MdiIcons.weatherWindy,
                       iconColor: Colors.lightGreen,
                       title: const Text('Current wind gust'),
-                      text: observations.wind.gustSpeed != null
+                      text: !observations.wind.gustSpeed.isNaN
                           ? Text('${observations.wind.gustSpeed} km/h')
                           : const Text('Unknown'),
                       subtext: const Text('Gust'),

--- a/lib/data/preference_model.dart
+++ b/lib/data/preference_model.dart
@@ -7,6 +7,7 @@ import './weather_model.dart';
 class PreferenceModel extends ChangeNotifier with WidgetsBindingObserver {
   static PreferenceModel _self;
   String _theme = 'system';
+  bool _seenPermissionExplanation = false;
 
   final ThemeData _lightTheme = ThemeData(
     brightness: Brightness.light,
@@ -22,6 +23,8 @@ class PreferenceModel extends ChangeNotifier with WidgetsBindingObserver {
   /// Constructor.
   PreferenceModel() {
     _theme = PrefService.getString('ui_theme');
+    _seenPermissionExplanation =
+        PrefService.getBool('seen_permission_explanation');
     _self = this;
     WidgetsBinding.instance.addObserver(this);
   }
@@ -68,6 +71,20 @@ class PreferenceModel extends ChangeNotifier with WidgetsBindingObserver {
     }
     return _darkTheme;
   }
+
+  bool get seenPermissionExplanation => _seenPermissionExplanation ?? false;
+
+  static void sawPermissionExplanation() {
+    _self._sawPermissionExplanation();
+  }
+
+  void _sawPermissionExplanation() {
+    PrefService.setBool('seen_permission_explanation', true);
+    _seenPermissionExplanation = true;
+    notifyListeners();
+  }
+
+  String get theme => _theme;
 
   static void updateTheme(String theme) {
     _self._updateTheme(theme);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,7 +23,8 @@ Future<void> main() async {
   runApp(MultiProvider(
     providers: <ChangeNotifierProvider<dynamic>>[
       ChangeNotifierProvider<LocationModel>(
-          create: (BuildContext context) => LocationModel()),
+          create: (BuildContext context) =>
+              LocationModel(loadDataImmediately: false)),
       ChangeNotifierProvider<WeatherModel>(
           create: (BuildContext context) => WeatherModel(context: context)),
       ChangeNotifierProvider<PreferenceModel>(

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -52,25 +52,6 @@ class AppState extends State<HomePage> {
           // We don't yet have permission, let's request that.
           if (data.item1 == LocationPermission.denied ||
               data.item1 == LocationPermission.deniedForever) {
-            final List<Widget> _text = <Widget>[
-              const Text(
-                'Welcome to Tidy Weather!',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 24),
-            ];
-            if (data.item1 == LocationPermission.denied) {
-              _text.add(const Text(
-                  'In order to display your weather, we need permission to '
-                  'check your location. Allowing location access all of the '
-                  'time will ensure your weather is always up to date, even '
-                  "when the app isn't open."));
-            } else {
-              _text.add(const Text(
-                  'In order to display your weather, we need permission to '
-                  "check your location. You'll need to allow location access "
-                  'in the device settings.'));
-            }
             return Scaffold(
               appBar: AppBar(
                 title: const Text('Tidy Weather'),
@@ -82,17 +63,18 @@ class AppState extends State<HomePage> {
                   child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
-                        ..._text,
+                        const Text(
+                          'Welcome to Tidy Weather!',
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 24),
+                        const Text('In order to display your weather, we need '
+                            "permission to check your location. You'll need to "
+                            'allow location access in the device settings.'),
                         const SizedBox(height: 16),
                         ElevatedButton(
                           onPressed: () async {
-                            if (data.item1 == LocationPermission.denied) {
-                              await Geolocator.requestPermission();
-                            } else {
-                              await Geolocator.openAppSettings();
-                            }
-
-                            await LocationModel.load();
+                            await LocationModel.requestPermission();
                           },
                           child: const Text('Grant Location Permission'),
                         )

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:preferences/preferences.dart';
+import 'package:provider/provider.dart';
+import 'package:tuple/tuple.dart';
 
+import '../data/location_model.dart';
 import '../data/preference_model.dart';
 
 /// The settings page.
@@ -17,34 +21,127 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   @override
-  Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(
-          title: const Text('Settings'),
+  Widget build(BuildContext context) => Selector2<PreferenceModel,
+          LocationModel, Tuple3<bool, LocationPermission, Color>>(
+        selector: (BuildContext context, PreferenceModel preferences,
+                LocationModel location) =>
+            Tuple3<bool, LocationPermission, Color>(
+          preferences.seenPermissionExplanation,
+          location.permissionStatus,
+          Theme.of(context).iconTheme.color,
         ),
-        body: PreferencePage(<Widget>[
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              PreferenceTitle('Theme'),
-              RadioPreference<String>(
-                'System theme',
-                'system',
-                'ui_theme',
-                isDefault: true,
-                onSelect: () {
-                  PreferenceModel.updateTheme('system');
-                },
+        builder: (BuildContext context,
+            Tuple3<bool, LocationPermission, Color> data, Widget child) {
+          Container permissionMessage;
+          Text permissionButton;
+          bool highlightPermission = !data.item1;
+          switch (data.item2) {
+            case LocationPermission.denied:
+            case LocationPermission.deniedForever:
+              permissionMessage = Container(
+                margin: const EdgeInsets.all(16),
+                child: const Text(
+                    'In order to provide accurate weather data, Tidy '
+                    'Weather requires permission to access to your location. '
+                    'Your exact location never leaves your device, and your '
+                    'approximate location is only used for gathering accurate '
+                    'weather data.'),
+              );
+              permissionButton = const Text('Grant Location Permission');
+              break;
+            case LocationPermission.whileInUse:
+              permissionMessage = Container(
+                margin: const EdgeInsets.all(16),
+                child: const Text(
+                    "Tidy Weather does work if it's only able to check your "
+                    "location while it's open. However, it works best when it "
+                    'has permission to check your location in the background, '
+                    'too.'),
+              );
+              permissionButton = const Text('Grant Location Permission');
+              break;
+            case LocationPermission.always:
+              // No need to display a message when we have all permissions.
+              permissionButton = const Text('Open Location Permissions');
+              highlightPermission = false;
+              break;
+          }
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Settings'),
+            ),
+            body: PreferencePage(<Widget>[
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  PreferenceTitle('Theme'),
+                  RadioPreference<String>(
+                    'System theme',
+                    'system',
+                    'ui_theme',
+                    isDefault: true,
+                    onSelect: () {
+                      PreferenceModel.updateTheme('system');
+                    },
+                  ),
+                  RadioPreference<String>(
+                    'Dark theme after sunset',
+                    'sun',
+                    'ui_theme',
+                    onSelect: () {
+                      PreferenceModel.updateTheme('sun');
+                    },
+                  ),
+                  Container(
+                    color: highlightPermission
+                        ? Theme.of(context).highlightColor
+                        : null,
+                    padding: const EdgeInsets.fromLTRB(0, 0, 0, 16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Row(
+                          children: <Widget>[
+                            if (highlightPermission)
+                              Padding(
+                                padding:
+                                    const EdgeInsets.only(left: 10, top: 20),
+                                child: Icon(
+                                  Icons.warning,
+                                  color: data.item3,
+                                  size: Theme.of(context)
+                                      .textTheme
+                                      .bodyText1
+                                      .fontSize,
+                                ),
+                              ),
+                            PreferenceTitle('Permissions'),
+                          ],
+                        ),
+                        if (permissionMessage != null) permissionMessage,
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: <Widget>[
+                              ElevatedButton(
+                                onPressed: () async {
+                                  await LocationModel.requestPermission(
+                                    forceOpen: true,
+                                  );
+                                },
+                                child: permissionButton,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-              RadioPreference<String>(
-                'Dark theme after sunset',
-                'sun',
-                'ui_theme',
-                onSelect: () {
-                  PreferenceModel.updateTheme('sun');
-                },
-              ),
-            ],
-          ),
-        ]),
+            ]),
+          );
+        },
       );
 }

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -1,43 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:provider/provider.dart';
+import 'package:tidyweather/data/location_model.dart';
 
+import '../data/preference_model.dart';
 import '../pages/about.dart';
 import '../pages/settings.dart';
 
 /// Creates the main drawer for the app.
 Drawer buildDrawer(BuildContext context, String currentRoute) => Drawer(
-      child: ListView(
-        padding: EdgeInsets.zero,
-        children: <Widget>[
-          DrawerHeader(
-            decoration: BoxDecoration(
-              color: Theme.of(context).primaryColor,
-            ),
-            child: const Text(
-              'Tidy Weather',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 24,
+      child: Selector2<PreferenceModel, LocationModel, bool>(
+        selector: (BuildContext context, PreferenceModel preferences,
+                LocationModel location) =>
+            !preferences.seenPermissionExplanation &&
+            location.permissionStatus != LocationPermission.always,
+        builder:
+            (BuildContext context, bool showPermissionWarning, Widget child) =>
+                ListView(
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            DrawerHeader(
+              decoration: BoxDecoration(
+                color: Theme.of(context).primaryColor,
+              ),
+              child: const Text(
+                'Tidy Weather',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                ),
               ),
             ),
-          ),
-          ListTile(
-            leading: const Icon(Icons.settings),
-            title: const Text('Settings'),
-            selected: currentRoute == SettingsPage.route,
-            onTap: () {
-              Navigator.pop(context);
-              Navigator.pushNamed(context, SettingsPage.route);
-            },
-          ),
-          const Divider(),
-          ListTile(
-            title: const Text('About Tidy Weather'),
-            selected: currentRoute == AboutPage.route,
-            onTap: () {
-              Navigator.pop(context);
-              Navigator.pushNamed(context, AboutPage.route);
-            },
-          ),
-        ],
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Settings'),
+              trailing:
+                  showPermissionWarning ? const Icon(Icons.warning) : null,
+              selected: currentRoute == SettingsPage.route,
+              onTap: () async {
+                Navigator.pop(context);
+                await Navigator.pushNamed(context, SettingsPage.route);
+                PreferenceModel.sawPermissionExplanation();
+              },
+            ),
+            const Divider(),
+            ListTile(
+              title: const Text('About Tidy Weather'),
+              selected: currentRoute == AboutPage.route,
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, AboutPage.route);
+              },
+            ),
+          ],
+        ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: ansicolor
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.1"
   archive:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   background_fetch:
     dependency: "direct main"
     description:
@@ -42,7 +42,7 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   cached_network_image:
     dependency: transitive
     description:
@@ -56,28 +56,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   console_log_handler:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   ffi:
     dependency: transitive
     description:
@@ -173,7 +173,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.2+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -204,7 +204,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4+1"
+    version: "6.1.7"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -215,10 +215,12 @@ packages:
   gradient_app_bar:
     dependency: "direct main"
     description:
-      name: gradient_app_bar
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
+      path: "."
+      ref: HEAD
+      resolved-ref: "1fafc17bad94041e17ae2ab81d6257b4d9333d79"
+      url: "git://github.com/TinyProgrammers/GradientAppBar.git"
+    source: git
+    version: "0.1.4"
   http:
     dependency: "direct main"
     description:
@@ -239,7 +241,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.18"
+    version: "2.1.19"
   intl:
     dependency: transitive
     description:
@@ -260,7 +262,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.1"
+    version: "0.6.3-nullsafety.3"
   latlong:
     dependency: "direct main"
     description:
@@ -288,7 +290,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   material_design_icons_flutter:
     dependency: "direct main"
     description:
@@ -302,7 +304,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.6"
   mgrs_dart:
     dependency: transitive
     description:
@@ -330,7 +332,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   path_drawing:
     dependency: transitive
     description:
@@ -449,7 +451,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4+1"
+    version: "2.1.5"
   rxdart:
     dependency: transitive
     description:
@@ -510,7 +512,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   sqflite:
     dependency: transitive
     description:
@@ -531,21 +533,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   synchronized:
     dependency: transitive
     description:
@@ -559,14 +561,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   transparent_image:
     dependency: transitive
     description:
@@ -587,7 +589,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   unicode:
     dependency: transitive
     description:
@@ -657,14 +659,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.3"
+    version: "1.7.4"
   wkt_parser:
     dependency: transitive
     description:
@@ -694,5 +696,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.2 <=2.11.0-213.1.beta"
-  flutter: ">=1.22.2 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.24.0-6.0.pre <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,17 +7,18 @@ environment:
   sdk: ">=2.3.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-
   background_fetch: ^0.6.0
   flip_card: ^0.4.4
+  flutter:
+    sdk: flutter
   flutter_launcher_icons: ^0.8.1
   flutter_map: ^0.10.1
-  flutter_svg: ^0.19.1
+  flutter_svg: ^0.19.2+1
   geocoding: ^1.0.5
-  geolocator: ^6.1.4
-  gradient_app_bar: ^0.1.3
+  geolocator: ^6.1.7
+  gradient_app_bar:
+    git:
+      url: git://github.com/TinyProgrammers/GradientAppBar.git
   http: ^0.12.2
   jiffy: ^3.0.1
   latlong: ^0.6.1
@@ -38,6 +39,9 @@ flutter_icons:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# When we need to use git dependencies, avoid showing a lint warning.
+publish_to: none
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
Previously, Tidy Weather generally just assumed that you granted full location permissions immediately, and didn't really handle any other cases. This PR improves the situation in several ways:

- If location permissions are denied on first open, show a message explaining why we need location, and a button to open the permission dialog again.
- If it's denied a second time, Android requires it to be granted from the app info screen, rather than the permission popup. If that's the case, we correctly send the user here.
- When permissions change, we immediately respond appropriately to the change, rather than waiting for the user to refresh.
- If permission is denied, or set to "Allow only while using the app", we add a warning icon to the Settings menu item, and highlight the new Permissions section of the Settings page. This warning icon is removed after the Settings page has been visited.

<img width="400" src="https://user-images.githubusercontent.com/352291/99893073-03975080-2cd0-11eb-8378-3d4b8eece4ae.png"/> <img width="400" src="https://user-images.githubusercontent.com/352291/99893075-08f49b00-2cd0-11eb-9834-1f979f430bd3.png"/> <img width="400" src="https://user-images.githubusercontent.com/352291/99893080-0c882200-2cd0-11eb-90cf-785d10980ec9.png"/> <img width="400" src="https://user-images.githubusercontent.com/352291/99893087-1578f380-2cd0-11eb-8791-4615f2074e77.png"/> <img width="400" src="https://user-images.githubusercontent.com/352291/99893088-1873e400-2cd0-11eb-8c30-6f09abf96262.png"/>
